### PR TITLE
Support for non-korean datasets. (and other modifications)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ Follow below commands. (explain with `son` dataset)
 
 Because the automatic generation is extremely naive, the dataset is noisy. However, if you have enough datasets (20+ hours with random initialization or 5+ hours with pretrained model initialization), you can expect an acceptable quality of audio synthesis.
 
+### 2-3. Generate English datasets
+
+1. Download speech dataset at https://keithito.com/LJ-Speech-Dataset/
+
+2. Convert metadata CSV file to json file. (arguments are available for changing preferences)
+		
+		python3 -m datasets.LJSpeech_1_0.prepare
+
+3. Finally, generate numpy files which will be used in training.
+		
+		python3 -m datasets.generate_data ./datasets/LJSpeech_1_0
+		
 
 ### 3. Train a model
 
@@ -126,7 +138,13 @@ You can train your own models with:
 or generate audio directly with:
 
     python3 synthesizer.py --load_path logs/son-20171015 --text "이거 실화냐?"
+	
+### 4-1. Synthesizing non-korean(english) audio
 
+For generating non-korean audio, you must set the argument --is_korean False.
+		
+		python3 app.py --load_path logs/LJSpeech_1_0-20180108 --num_speakers=1 --is_korean=False
+		python3 synthesizer.py --load_path logs/LJSpeech_1_0-20180108 --text="Winter is coming." --is_korean=False
 
 ## Results
 

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ or generate audio directly with:
 
 For generating non-korean audio, you must set the argument --is_korean False.
 		
-		python3 app.py --load_path logs/LJSpeech_1_0-20180108 --num_speakers=1 --is_korean=False
-		python3 synthesizer.py --load_path logs/LJSpeech_1_0-20180108 --text="Winter is coming." --is_korean=False
+	python3 app.py --load_path logs/LJSpeech_1_0-20180108 --num_speakers=1 --is_korean=False
+	python3 synthesizer.py --load_path logs/LJSpeech_1_0-20180108 --text="Winter is coming." --is_korean=False
 
 ## Results
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 #!flask/bin/python
-import os
+# -*- coding: cp949 -*-
+import os, traceback
 import hashlib
 import argparse
 from flask_cors import CORS
@@ -56,6 +57,8 @@ def generate_audio_response(text, speaker_id):
     global global_config
 
     model_name = os.path.basename(global_config.load_path)
+    isKorean=global_config.is_korean
+    
     hashed_text = hashlib.md5(text.encode('utf-8')).hexdigest()
 
     relative_dir_path = os.path.join(AUDIO_DIR, model_name)
@@ -68,8 +71,9 @@ def generate_audio_response(text, speaker_id):
         try:
             audio = synthesizer.synthesize(
                     [text], paths=[real_path], speaker_ids=[speaker_id],
-                    attention_trim=True)[0]
-        except:
+                    attention_trim=True, isKorean=isKorean)[0]
+        except Exception as e:
+            traceback.print_exc()
             return jsonify(success=False), 400
 
     return send_file(
@@ -85,7 +89,7 @@ def generate_audio_response(text, speaker_id):
 
 @app.route('/')
 def index():
-    text = request.args.get('text') or "ë“£ê³  ì‹¶ì€ ë¬¸ì¥ì„ ì…ë ¥í•´ ì£¼ì„¸ìš”."
+    text = request.args.get('text') or "µè°í ½ÍÀº ¹®ÀåÀ» ÀÔ·ÂÇØ ÁÖ¼¼¿ä."
     return render_template('index.html', text=text)
 
 @app.route('/generate')
@@ -118,8 +122,9 @@ if __name__ == '__main__':
     parser.add_argument('--load_path', required=True)
     parser.add_argument('--checkpoint_step', default=None, type=int)
     parser.add_argument('--num_speakers', default=1, type=int)
-    parser.add_argument('--port', default=5000, type=int)
+    parser.add_argument('--port', default=51000, type=int)
     parser.add_argument('--debug', default=False, type=str2bool)
+    parser.add_argument('--is_korean', default=True, type=str2bool)
     config = parser.parse_args()
 
     if os.path.exists(config.load_path):

--- a/audio/silence.py
+++ b/audio/silence.py
@@ -64,12 +64,17 @@ def split_on_silence_with_librosa(
         output_path = "{}/{}.{:04d}.{}".format(
                 os.path.dirname(audio_path), filename, idx, out_ext)
 
+        #added - remove trailing, heading silence
+        segment, idx=librosa.effects.trim(segment)
+
         padded_segment = np.concatenate([
                 get_silence(pre_silence_length),
                 segment,
                 get_silence(post_silence_length),
         ])
 
+
+        
         save_audio(padded_segment, output_path)
         audio_paths.append(output_path)
 
@@ -101,7 +106,7 @@ def split_on_silence_with_pydub(
             edges[-1][1] = not_silence_ranges[idx][1]
         else:
             edges.append(not_silence_ranges[idx])
-
+    
     audio_paths = []
     for idx, (start_idx, end_idx) in enumerate(edges[skip_idx:]):
         start_idx = max(0, start_idx - keep_silence)
@@ -110,7 +115,16 @@ def split_on_silence_with_pydub(
         target_audio_path = "{}/{}.{:04d}.{}".format(
                 os.path.dirname(audio_path), filename, idx, out_ext)
 
-        audio[start_idx:end_idx].export(target_audio_path, out_ext)
+        segment=audio[start_idx:end_idx]
+        #added - remove trailing, heading silence
+        #segment, idx=librosa.effects.trim(segment)
+        
+        segment.export(target_audio_path, out_ext)  # for soundsegment
+
+        # Now apply trimming for quality issue DONT
+        #segment, sr=librosa.core.load(target_audio_path, sr=24000)
+        #seg_t, idx=librosa.effects.trim(segment)
+        #save_audio(seg_t, target_audio_path)
 
         audio_paths.append(target_audio_path)
 

--- a/audio/silence.py
+++ b/audio/silence.py
@@ -64,9 +64,6 @@ def split_on_silence_with_librosa(
         output_path = "{}/{}.{:04d}.{}".format(
                 os.path.dirname(audio_path), filename, idx, out_ext)
 
-        #added - remove trailing, heading silence
-        segment, idx=librosa.effects.trim(segment)
-
         padded_segment = np.concatenate([
                 get_silence(pre_silence_length),
                 segment,
@@ -116,15 +113,8 @@ def split_on_silence_with_pydub(
                 os.path.dirname(audio_path), filename, idx, out_ext)
 
         segment=audio[start_idx:end_idx]
-        #added - remove trailing, heading silence
-        #segment, idx=librosa.effects.trim(segment)
         
         segment.export(target_audio_path, out_ext)  # for soundsegment
-
-        # Now apply trimming for quality issue DONT
-        #segment, sr=librosa.core.load(target_audio_path, sr=24000)
-        #seg_t, idx=librosa.effects.trim(segment)
-        #save_audio(seg_t, target_audio_path)
 
         audio_paths.append(target_audio_path)
 

--- a/datasets/LJSpeech_1_0/README
+++ b/datasets/LJSpeech_1_0/README
@@ -1,0 +1,130 @@
+-----------------------------------------------------------------------------
+The LJ Speech Dataset
+
+Version 1.0
+July 5, 2017
+https://keithito.com/LJ-Speech-Dataset
+-----------------------------------------------------------------------------
+
+
+OVERVIEW
+
+This is a public domain speech dataset consisting of 13,100 short audio clips
+of a single speaker reading passages from 7 non-fiction books. A transcription
+is provided for each clip. Clips vary in length from 1 to 10 seconds and have
+a total length of approximately 24 hours.
+
+The texts were published between 1884 and 1964, and are in the public domain.
+The audio was recorded in 2016-17 by the LibriVox project and is also in the
+public domain.
+
+
+
+FILE FORMAT
+
+Metadata is provided in metadata.csv. This file consists of one record per
+line, delimited by the pipe character (0x7c). The fields are:
+
+  1. ID: this is the name of the corresponding .wav file
+  2. Transcription: words spoken by the reader (UTF-8)
+  3. Normalized Transcription: transcription with numbers, ordinals, and
+     monetary units expanded into full words (UTF-8).
+
+Each audio file is a single-channel 16-bit PCM WAV with a sample rate of
+22050 Hz.
+
+
+
+STATISTICS
+
+Total Clips            13,100
+Total Words            225,715
+Total Characters       1,308,674
+Total Duration         23:55:17
+Mean Clip Duration     6.57 sec
+Min Clip Duration      1.11 sec
+Max Clip Duration      10.10 sec
+Mean Words per Clip    17.23
+Distinct Words         13,821
+
+
+
+MISCELLANEOUS
+
+The audio clips range in length from approximately 1 second to 10 seconds.
+They were segmented automatically based on silences in the recording. Clip
+boundaries generally align with sentence or clause boundaries, but not always.
+
+The text was matched to the audio manually, and a QA pass was done to ensure
+that the text accurately matched the words spoken in the audio.
+
+The original LibriVox recordings were distributed as 128 kbps MP3 files. As a
+result, they may contain artifacts introduced by the MP3 encoding.
+
+The following abbreviations appear in the text. They may be expanded as
+follows:
+
+     Abbreviation   Expansion
+     --------------------------
+     Mr.            Mister
+     Mrs.           Misess (*)
+     Dr.            Doctor
+     No.            Number
+     St.            Saint
+     Co.            Company
+     Jr.            Junior
+     Maj.           Major
+     Gen.           General
+     Drs.           Doctors
+     Rev.           Reverend
+     Lt.            Lieutenant
+     Hon.           Honorable
+     Sgt.           Sergeant
+     Capt.          Captain
+     Esq.           Esquire
+     Ltd.           Limited
+     Col.           Colonel
+     Ft.            Fort
+
+     * there's no standard expansion of "Mrs."
+
+
+19 of the transcriptions contain non-ASCII characters (for example, LJ016-0257
+contains "raison d'être").
+
+For more information or to report errors, please email kito@kito.us.
+
+
+
+LICENSE
+
+This dataset is in the public domain in the USA (and likely other countries as
+well). There are no restrictions on its use. For more information, please see:
+https://librivox.org/pages/public-domain.
+
+
+
+CREDITS
+
+This dataset consists of excerpts from the following works:
+
+* Morris, William, et al. Arts and Crafts Essays. 1893.
+* Griffiths, Arthur. The Chronicles of Newgate, Vol. 2. 1884.
+* Roosevelt, Franklin D. The Fireside Chats of Franklin Delano Roosevelt.
+  1933-42.
+* Harland, Marion. Marion Harland's Cookery for Beginners. 1893.
+* Rolt-Wheeler, Francis. The Science - History of the Universe, Vol. 5:
+  Biology. 1910.
+* Banks, Edgar J. The Seven Wonders of the Ancient World. 1916.
+* President's Commission on the Assassination of President Kennedy. Report
+  of the President's Commission on the Assassination of President Kennedy.
+  1964.
+
+Recordings by Linda Johnson. Alignment and annotation by Keith Ito. All text,
+audio, and annotations are in the public domain.
+
+If you would like to cite this work, please do so by linking to:
+  https://keithito.com/LJ-Speech-Dataset
+
+or by using the citation:
+  Ito, Keith. The LJ Speech Dataset. 2017. https://keithito.com/LJ-Speech-Dataset.

--- a/datasets/LJSpeech_1_0/prepare.py
+++ b/datasets/LJSpeech_1_0/prepare.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Jan  4 10:50:07 2018
+# Conversion tool for https://github.com/carpedm20/multi-speaker-tacotron-tensorflow
+This prepares LJ-Dataset (available at https://keithito.com/LJ-Speech-Dataset/) to json and wav format
+that can be processed into .npz file using datasets.generate_data. 
+
+@author: engiecat (github)
+"""
+import os
+from utils import load_json, write_json, backup_file, str2bool
+import argparse
+
+base_dir = os.path.dirname(os.path.realpath(__file__))
+work_dir = os.getcwd()
+class Data(object):
+    def __init__(
+            self, audio_name, audio_transcript,audio_normalized_transcript,audio_path='ERR'):
+        self.audio_name = audio_name
+        self.audio_transcript = audio_transcript
+        self.audio_normalized_transcript=audio_normalized_transcript
+        self.audio_path = audio_path
+
+def read_csv(path,fn_encoding='UTF8'):
+    # reads csv file into audio snippet name and its transcript
+    with open(path, encoding=fn_encoding) as f:
+        data = []
+        temp='' # for storing non-normalized
+        for line in f:
+            audio_name, audio_transcript,audio_normalized_transcript = line.split('|')
+            audio_transcript=audio_transcript.strip()
+            audio_normalized_transcript=audio_normalized_transcript.strip()
+            data.append(Data(audio_name, audio_transcript,audio_normalized_transcript))
+        return data
+
+def convert_name_to_path(name, audio_dir, audio_format):
+    # converts audio snippet name to audio snippet path
+    abs_audio_dir=os.path.abspath(os.path.join(base_dir,audio_dir))
+    # the audio directory is respective to dataset folder(base_dir)
+    # while the working directory is at the root directory (work_dir)
+    result= os.path.join('./',os.path.relpath(abs_audio_dir,work_dir), name+'.'+audio_format )
+    return result
+
+def convert_to_json_format(data, is_normalized):
+    # converts into json format
+    if is_normalized:
+        result={data.audio_path:[data.audio_normalized_transcript]}
+    else:
+        result={data.audio_path:[data.audio_transcript]}
+    return result
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--metadata', default="metadata.csv")
+    parser.add_argument('--metadata_enconding', default="UTF8")
+    parser.add_argument('--audio_dir', default="wavs")
+    parser.add_argument('--audio_format', default='wav')
+    parser.add_argument('--alignment_filename', default="alignment.json")
+    parser.add_argument('--use_normalize', default=True, type=str2bool)
+    config = parser.parse_args()
+    
+    print(' [*] Reading metadata file - '+config.metadata)
+    data = read_csv(os.path.join(base_dir, config.metadata))
+    print(' [*] Converting to audio_path...')
+    results={}
+    for d in data:
+        d.audio_path=convert_name_to_path(d.audio_name,config.audio_dir,config.audio_format) 
+        results.update(convert_to_json_format(d, config.use_normalize))
+    print(' [*] Saving to json...')
+    alignment_path = \
+        os.path.join(base_dir, config.alignment_filename)
+    if os.path.exists(alignment_path):
+        backup_file(alignment_path)
+    write_json(alignment_path, results)
+    print(' [!] All Done!')
+    print(work_dir)
+    

--- a/hparams.py
+++ b/hparams.py
@@ -15,7 +15,7 @@ basic_params.update({
     # Audio
     'num_mels': 80,
     'num_freq': 1025,
-    'sample_rate': 20000, 
+    'sample_rate': 24000, # trained as 20000 but need to be 24000 
     'frame_length_ms': 50,
     'frame_shift_ms': 12.5,
     'preemphasis': 0.97,
@@ -25,7 +25,7 @@ basic_params.update({
 
 if True:
     basic_params.update({
-        'sample_rate': 22050, #originally 24000 (krbook), 22050(lj-data), 20000(others) 
+        'sample_rate': 24000, #originally 24000 (krbook), 22050(lj-data), 20000(others) 
     })
 
 basic_params.update({
@@ -68,7 +68,7 @@ basic_params.update({
     'reduction_factor': 4,
 })
 
-if False: # Deep Voice 2
+if False: # Deep Voice 2 AudioBook Dataset
     basic_params.update({
         'dropout_prob': 0.8,
 
@@ -80,7 +80,7 @@ if False: # Deep Voice 2
 
         'reduction_factor': 5, # changed from 4
     })
-elif False: # Deep Voice 2 init
+elif False: # Deep Voice 2 VCTK dataset
     basic_params.update({
         'dropout_prob': 0.8,
 
@@ -90,7 +90,7 @@ elif False: # Deep Voice 2 init
         #'post_bank_channel_size': f(512),
         'post_rnn_size': f(256),
 
-        'reduction_factor': 4,
+        'reduction_factor': 5,
     })
 elif True: # Single Speaker
     basic_params.update({
@@ -125,7 +125,7 @@ basic_params.update({
     'use_fixed_test_inputs': False,
 
     'initial_learning_rate': 0.001,
-    'decay_learning_rate_mode': 0,
+    'decay_learning_rate_mode': 0, # True in deepvoice2 paper
     'initial_data_greedy': True,
     'initial_phase_step': 8000,
     'main_data_greedy_factor': 0,
@@ -136,7 +136,7 @@ basic_params.update({
     'ignore_recognition_level': 0, # 0: use all, 1: ignore only unmatched_alignment, 2: fully ignore recognition
 
     # Eval
-    'min_tokens': 50,#originally 50, 30 is good for korean,
+    'min_tokens': 30,#originally 50, 30 is good for korean,
     'min_iters': 30,
     'max_iters': 200,
     'skip_inadequate': False,

--- a/hparams.py
+++ b/hparams.py
@@ -8,14 +8,14 @@ def f(num):
 basic_params = {
     # Comma-separated list of cleaners to run on text prior to training and eval. For non-English
     # text, you may want to use "basic_cleaners" or "transliteration_cleaners" See TRAINING_DATA.md.
-    'cleaners': 'korean_cleaners',
+    'cleaners': 'english_cleaners', #originally korean_cleaners
 }
 
 basic_params.update({
     # Audio
     'num_mels': 80,
     'num_freq': 1025,
-    'sample_rate': 20000,
+    'sample_rate': 20000, 
     'frame_length_ms': 50,
     'frame_shift_ms': 12.5,
     'preemphasis': 0.97,
@@ -25,7 +25,7 @@ basic_params.update({
 
 if True:
     basic_params.update({
-        'sample_rate': 24000,
+        'sample_rate': 22050, #originally 24000 (krbook), 22050(lj-data), 20000(others) 
     })
 
 basic_params.update({
@@ -78,9 +78,9 @@ if False: # Deep Voice 2
         'post_bank_channel_size': f(512),
         'post_rnn_size': f(256),
 
-        'reduction_factor': 4,
+        'reduction_factor': 5, # changed from 4
     })
-elif True: # Deep Voice 2
+elif False: # Deep Voice 2 init
     basic_params.update({
         'dropout_prob': 0.8,
 
@@ -92,7 +92,7 @@ elif True: # Deep Voice 2
 
         'reduction_factor': 4,
     })
-elif False: # Single Speaker
+elif True: # Single Speaker
     basic_params.update({
         'dropout_prob': 0.5,
 
@@ -101,7 +101,7 @@ elif False: # Single Speaker
         'post_bank_channel_size': f(128),
         #'post_rnn_size': f(128),
 
-        'reduction_factor': 4,
+        'reduction_factor': 5, #chhanged from 4
     })
 elif False: # Single Speaker with generalization
     basic_params.update({
@@ -119,12 +119,12 @@ elif False: # Single Speaker with generalization
 
 basic_params.update({
     # Training
-    'batch_size': 16,
+    'batch_size': 32,
     'adam_beta1': 0.9,
     'adam_beta2': 0.999,
     'use_fixed_test_inputs': False,
 
-    'initial_learning_rate': 0.002,
+    'initial_learning_rate': 0.001,
     'decay_learning_rate_mode': 0,
     'initial_data_greedy': True,
     'initial_phase_step': 8000,
@@ -133,10 +133,10 @@ basic_params.update({
     'prioritize_loss': False,
 
     'recognition_loss_coeff': 0.2,
-    'ignore_recognition_level': 1, # 0: use all, 1: ignore only unmatched_alignment, 2: fully ignore recognition
+    'ignore_recognition_level': 0, # 0: use all, 1: ignore only unmatched_alignment, 2: fully ignore recognition
 
     # Eval
-    'min_tokens': 50,
+    'min_tokens': 50,#originally 50, 30 is good for korean,
     'min_iters': 30,
     'max_iters': 200,
     'skip_inadequate': False,

--- a/hparams.py
+++ b/hparams.py
@@ -25,7 +25,7 @@ basic_params.update({
 
 if True:
     basic_params.update({
-        'sample_rate': 24000, #originally 24000 (krbook), 22050(lj-data), 20000(others) 
+        'sample_rate': 22050, #originally 24000 (krbook), 22050(lj-data), 20000(others) 
     })
 
 basic_params.update({

--- a/hparams.py
+++ b/hparams.py
@@ -136,7 +136,7 @@ basic_params.update({
     'ignore_recognition_level': 0, # 0: use all, 1: ignore only unmatched_alignment, 2: fully ignore recognition
 
     # Eval
-    'min_tokens': 30,#originally 50, 30 is good for korean,
+    'min_tokens': 50,#originally 50, 30 is good for korean,
     'min_iters': 30,
     'max_iters': 200,
     'skip_inadequate': False,

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -13,5 +13,7 @@ def get_most_recent_checkpoint(checkpoint_dir):
 
     max_idx = max(idxes)
     lastest_checkpoint = os.path.join(checkpoint_dir, "model.ckpt-{}".format(max_idx))
+
+    #latest_checkpoint=checkpoint_paths[0]
     print(" [*] Found lastest checkpoint: {}".format(lastest_checkpoint))
     return lastest_checkpoint

--- a/recognition/alignment.py
+++ b/recognition/alignment.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import string
 import argparse
@@ -102,7 +103,7 @@ def align_text_fn(
     news_path = os.path.splitext(news_path)[0] + ".txt"
 
     strip_fn = lambda line: line.strip().replace('"', '').replace("'", "")
-    candidates = [strip_fn(line) for line in open(news_path).readlines()]
+    candidates = [strip_fn(line) for line in open(news_path, encoding='cp949').readlines()]
 
     scores = { candidate: similarity(candidate, recognition_text) \
                     for candidate in candidates}
@@ -140,7 +141,7 @@ def align_text_batch(config):
             score_threshold=config.score_threshold)
 
     results = {}
-    data = load_json(config.recognition_path)
+    data = load_json(config.recognition_path, encoding=config.recognition_encoding)
 
     items = parallel_run(
             align_text, data.items(),
@@ -162,6 +163,7 @@ if __name__ == '__main__':
     parser.add_argument('--recognition_path', required=True)
     parser.add_argument('--alignment_filename', default="alignment.json")
     parser.add_argument('--score_threshold', default=0.4, type=float)
+    parser.add_argument('--recognition_encoding', default='949')
     config, unparsed = parser.parse_known_args()
 
     results = align_text_batch(config)

--- a/recognition/google.py
+++ b/recognition/google.py
@@ -9,7 +9,6 @@ from functools import partial
 from utils import parallel_run, remove_file, backup_file, write_json
 from audio import load_audio, save_audio, resample_audio, get_duration
 
-
 def text_recognition(path, config):
     root, ext = os.path.splitext(path)
     txt_path = root + ".txt"
@@ -27,11 +26,12 @@ def text_recognition(path, config):
     error_count = 0
 
     tmp_path = os.path.splitext(path)[0] + ".tmp.wav"
+    client = speech.SpeechClient() # Fixed
 
     while True:
         try:
-            client = speech.SpeechClient()
-
+            # client= speech.SpeechClient() # Causes 10060 max retries exceeded -to OAuth -HK
+            
             content = load_audio(
                     path, pre_silence_length=config.pre_silence_length,
                     post_silence_length=config.post_silence_length)

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ ipython==6.2.1
 ipython-genutils==0.2.0
 iso8601==0.1.12
 itsdangerous==0.24
-jamo==0.4.0
+jamo==0.4.1
 jedi==0.11.0
 Jinja2==2.9.6
 joblib==0.11
@@ -98,8 +98,8 @@ scipy==0.19.1
 simplegeneric==0.8.1
 six==1.11.0
 tenacity==4.4.0
-tensorflow==1.3.0
-tensorflow-tensorboard==0.1.8
+#tensorflow-gpu==1.3.0
+#tensorflow-tensorboard==0.1.8
 tinytag==0.18.0
 tqdm==4.19.2
 traitlets==4.3.2

--- a/synthesizer.py
+++ b/synthesizer.py
@@ -14,7 +14,7 @@ from models import create_model, get_most_recent_checkpoint
 from audio import save_audio, inv_spectrogram, inv_preemphasis, \
                   inv_spectrogram_tensorflow
 from utils import plot, PARAMS_NAME, load_json, load_hparams, \
-                  add_prefix, add_postfix, get_time, parallel_run, makedirs
+                  add_prefix, add_postfix, get_time, parallel_run, makedirs, str2bool
 
 from text.korean import tokenize
 from text import text_to_sequence, sequence_to_text
@@ -76,7 +76,8 @@ class Synthesizer(object):
             manual_attention_mode=0,
             base_alignment_path=None,
             librosa_trim=False,
-            attention_trim=True):
+            attention_trim=True,
+            isKorean=True):
 
         # Possible inputs:
         # 1) text=text
@@ -113,7 +114,8 @@ class Synthesizer(object):
                     use_manual_attention=use_manual_attention,
                     librosa_trim=librosa_trim,
                     attention_trim=attention_trim,
-                    time_str=time_str)
+                    time_str=time_str,
+                    isKorean=isKorean)
             return parallel_run(fn, items,
                     desc="plot_graph_and_save_audio", parallel=False)
 
@@ -214,7 +216,7 @@ def plot_graph_and_save_audio(args,
         use_short_concat=False,
         use_manual_attention=False, save_alignment=False,
         librosa_trim=False, attention_trim=False,
-        time_str=None):
+        time_str=None, isKorean=True):
 
     idx, (wav, alignment, path, text, sequence) = args
 
@@ -230,7 +232,7 @@ def plot_graph_and_save_audio(args,
         plot_path = add_postfix(plot_path, "manual")
 
     if plot_path:
-        plot.plot_alignment(alignment, plot_path, text=text)
+        plot.plot_alignment(alignment, plot_path, text=text, isKorean=isKorean)
 
     if use_short_concat:
         wav = short_concat(
@@ -375,6 +377,7 @@ if __name__ == "__main__":
     parser.add_argument('--num_speakers', default=1, type=int)
     parser.add_argument('--speaker_id', default=0, type=int)
     parser.add_argument('--checkpoint_step', default=None, type=int)
+    parser.add_argument('--is_korean', default=True, type=str2bool)
     config = parser.parse_args()
 
     makedirs(config.sample_path)
@@ -386,4 +389,5 @@ if __name__ == "__main__":
             texts=[config.text],
             base_path=config.sample_path,
             speaker_ids=[config.speaker_id],
-            attention_trim=False)[0]
+            attention_trim=False,
+            isKorean=config.is_korean)[0]

--- a/text/cleaners.py
+++ b/text/cleaners.py
@@ -14,6 +14,9 @@ hyperparameter. Some cleaners are English-specific. You'll typically want to use
 import re
 from .korean import tokenize as ko_tokenize
 
+# Added to support LJ_speech
+from unidecode import unidecode
+from .en_numbers import normalize_numbers as en_normalize_numbers
 
 # Regular expression matching whitespace:
 _whitespace_re = re.compile(r'\s+')
@@ -55,7 +58,7 @@ def expand_abbreviations(text):
 
 
 def expand_numbers(text):
-    return normalize_numbers(text)
+    return en_normalize_numbers(text)
 
 
 def lowercase(text):
@@ -65,6 +68,10 @@ def lowercase(text):
 def collapse_whitespace(text):
     return re.sub(_whitespace_re, ' ', text)
 
+def convert_to_ascii(text):
+    '''Converts to ascii, existed in keithito but deleted in carpedm20'''
+    return unidecode(text)
+    
 
 def basic_cleaners(text):
     '''Basic pipeline that lowercases and collapses whitespace without transliteration.'''
@@ -82,10 +89,12 @@ def transliteration_cleaners(text):
 
 
 def english_cleaners(text):
-  '''Pipeline for English text, including number and abbreviation expansion.'''
-  text = convert_to_ascii(text)
-  text = lowercase(text)
-  text = expand_numbers(text)
-  text = expand_abbreviations(text)
-  text = collapse_whitespace(text)
-  return text
+    '''Pipeline for English text, including number and abbreviation expansion.'''
+    text = convert_to_ascii(text)
+    text = lowercase(text)
+    text = expand_numbers(text)
+    text = expand_abbreviations(text)
+    text = collapse_whitespace(text)
+    return text
+
+

--- a/text/korean.py
+++ b/text/korean.py
@@ -1,4 +1,4 @@
-# Code based on 
+﻿# Code based on 
 
 import re
 import os

--- a/text/symbols.py
+++ b/text/symbols.py
@@ -9,5 +9,9 @@ from jamo.jamo import _jamo_char_to_hcj
 
 from .korean import ALL_SYMBOLS, PAD, EOS
 
-#symbols = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!\'(),-.:;? '
-symbols = ALL_SYMBOLS
+# For english
+#en_symbols = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!\'(),-.:;? '+EOS+PAD #<- For LJSpeech_1_0_2018-01-04_23-19-23 EOS location 63(enter it into train.py input_length calc part)
+en_symbols = PAD+EOS+'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!\'(),-.:;? '  #<-For deployment(Because korean ALL_SYMBOLS follow this convention)
+
+symbols = ALL_SYMBOLS # for korean
+

--- a/text/symbols.py
+++ b/text/symbols.py
@@ -10,7 +10,6 @@ from jamo.jamo import _jamo_char_to_hcj
 from .korean import ALL_SYMBOLS, PAD, EOS
 
 # For english
-#en_symbols = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!\'(),-.:;? '+EOS+PAD #<- For LJSpeech_1_0_2018-01-04_23-19-23 EOS location 63(enter it into train.py input_length calc part)
 en_symbols = PAD+EOS+'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!\'(),-.:;? '  #<-For deployment(Because korean ALL_SYMBOLS follow this convention)
 
 symbols = ALL_SYMBOLS # for korean

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -81,11 +81,11 @@ def get_time():
     return datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
 def write_json(path, data):
-    with open(path, 'w') as f:
+    with open(path, 'w',encoding='utf-8') as f:
         json.dump(data, f, indent=4, sort_keys=True, ensure_ascii=False)
 
-def load_json(path, as_class=False):
-    with open(path) as f:
+def load_json(path, as_class=False, encoding='euc-kr'):
+    with open(path,encoding=encoding) as f:
         content = f.read()
         content = re.sub(",\s*}", "}", content)
         content = re.sub(",\s*]", "]", content)
@@ -95,6 +95,7 @@ def load_json(path, as_class=False):
                     lambda data: namedtuple('Data', data.keys())(*data.values()))
         else:
             data = json.loads(content)
+    #print(data)
     return data
 
 def save_hparams(model_dir, hparams):

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -10,7 +10,7 @@ from text import PAD, EOS
 from utils import add_postfix
 from text.korean import normalize
 
-def plot(alignment, info, text):
+def plot(alignment, info, text, isKorean=True):
     char_len, audio_len = alignment.shape # 145, 200
 
     fig, ax = plt.subplots(figsize=(char_len/5, 5))
@@ -30,7 +30,10 @@ def plot(alignment, info, text):
     plt.ylabel(ylabel)
 
     if text:
-        jamo_text = j2hcj(h2j(normalize(text)))
+        if isKorean:
+            jamo_text = j2hcj(h2j(normalize(text)))
+        else:
+            jamo_text=text
         pad = [PAD] * (char_len - len(jamo_text) - 1)
 
         plt.xticks(range(char_len),
@@ -47,15 +50,15 @@ def plot(alignment, info, text):
     plt.tight_layout()
 
 def plot_alignment(
-        alignment, path, info=None, text=None):
+        alignment, path, info=None, text=None, isKorean=True):
 
     if text:
         tmp_alignment = alignment[:len(h2j(text)) + 2]
 
-        plot(tmp_alignment, info, text)
+        plot(tmp_alignment, info, text, isKorean)
         plt.savefig(path, format='png')
     else:
-        plot(alignment, info, text)
+        plot(alignment, info, text, isKorean)
         plt.savefig(path, format='png')
 
     print(" [*] Plot saved: {}".format(path))

--- a/web/static/js/main.js
+++ b/web/static/js/main.js
@@ -1,4 +1,4 @@
-var sw;
+﻿var sw;
 var wavesurfer;
 
 var defaultSpeed = 0.03;
@@ -96,7 +96,7 @@ function generate(ip, port, text, speaker_id) {
       var speaker_id = $('input[name=id]:checked').val();
       var speaker = $('input[name=id]:checked').attr("speaker");
 
-      generate('0.0.0.0', 5000, text, speaker_id);
+      generate('0.0.0.0', 51000, text, speaker_id);
 
       var lowpass = wavesurfer.backend.ac.createGain();
       wavesurfer.backend.setFilter(lowpass);

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -21,7 +21,7 @@
     <section class="hero is-fullheight dark">
       <div class="hero-body">
         <div class="container">
-          <div class="section-body" onKeyPress="return checkSubmit(event)">
+          <div class="section-body"">
             <div class="field">
               <div class="control">
                 <div class="columns">


### PR DESCRIPTION
 ### Changes

1. English datasets are now supported. (check README.md for more information) 

2. app.py had been fixed, and it now works in mobile. (at least in Android Chrome)

3. Created arguments for encodings.

### Tested for

1. LJ Datasets with single speaker settings (https://github.com/carpedm20/multi-speaker-tacotron-tensorflow/issues/6#issuecomment-356831556)

2. Korean datasets with single/multi speaker settings 
(I still have problems with multispeaker (it trains quite slowly in small batch size(8)(half-intelligible after 500k steps), but it seems unrelated to this PR)

Sorry for late PR! 
